### PR TITLE
adding pip installation to the process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,7 @@ USER root
 
 RUN apt-get update && apt-get install -y make mercurial rubygems-integration ruby python3 && rm -rf /var/lib/apt/lists/*
 RUN gem install bundler rake foreman
+RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN python3 get-pip.py
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 RUN apt-get update && apt-get install -y make mercurial rubygems-integration ruby python3 && rm -rf /var/lib/apt/lists/*
 RUN gem install bundler rake foreman
-RUN wget https://bootstrap.pypa.io/get-pip.py
-RUN python3 get-pip.py
+ADD https://bootstrap.pypa.io/get-pip.py /tmp
+RUN python3 /tmp/get-pip.py
 RUN pip install virtualenv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 RUN apt-get update && apt-get install -y make mercurial rubygems-integration ruby python3 && rm -rf /var/lib/apt/lists/*
 RUN gem install bundler rake foreman
-ADD https://bootstrap.pypa.io/get-pip.py /tmp
+ADD https://bootstrap.pypa.io/get-pip.py /tmp/
 RUN python3 /tmp/get-pip.py
 RUN pip install virtualenv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN apt-get update && apt-get install -y make mercurial rubygems-integration rub
 RUN gem install bundler rake foreman
 RUN wget https://bootstrap.pypa.io/get-pip.py
 RUN python3 get-pip.py
-
+RUN pip install virtualenv
 


### PR DESCRIPTION
Pip is required for Python package management. It does not ship by default with python versions <3.4, and apt does not have 3.4.